### PR TITLE
chore: 在.gitignore中添加GraphQL API View LLMs目录

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ app.*.map.json
 /android/app/release
 
 lib/secret.dart
+GraphQL API View LLMs/


### PR DESCRIPTION
避免将GraphQL API View LLMs相关文件提交到版本控制