### PR TITLE
讨论页面封面图片适配优化 (lib/pages/discussion_page.dart)

### DIFF
--- a/lib/pages/discussion_page.dart
+++ b/lib/pages/discussion_page.dart
@@ -1266,7 +1266,7 @@ class _CoverState extends State<Cover> {
                       child: isGif
                           ? Image.network(
                               url,
-                              fit: BoxFit.cover,
+                              fit: BoxFit.contain,
                               loadingBuilder: (context, child, p) {
                                 if (p == null) return child;
                                 return Center(
@@ -1287,7 +1287,7 @@ class _CoverState extends State<Cover> {
                             )
                           : CachedNetworkImage(
                               imageUrl: url,
-                              fit: BoxFit.cover,
+                              fit: BoxFit.contain,
                               progressIndicatorBuilder: (context, url, p) {
                                 return Center(
                                   child: CircularProgressIndicator(


### PR DESCRIPTION
讨论页面封面图片适配优化 (lib/pages/discussion_page.dart)

将 GIF 和普通图片的 fit 属性从 BoxFit.contain 改为 BoxFit.cover
改善封面图片的显示效果，使其填充整个容器