### PR TITLE
fix: 修复 DeltaToMarkdown 转换后多余换行的问题

### DIFF
--- a/lib/helpers/normalize_markdown.dart
+++ b/lib/helpers/normalize_markdown.dart
@@ -22,5 +22,10 @@ String normalizeMarkdown(String input) {
     RegExp(r'!\[([^\]]*)\]\(([^)\s]+)\)\s*\)+(?=\s|$)'),
     (m) => '![${m[1]}](${m[2]})',
   );
+  // Remove extra newlines added by DeltaToMarkdown (2 newlines -> 1).
+  out = out.replaceAllMapped(
+    RegExp(r'\n{2,}'),
+    (m) => '\n' * ((m[0]!.length + 1) ~/ 2),
+  );
   return out;
 }


### PR DESCRIPTION
移除由 DeltaToMarkdown 转换产生的多余换行符（将2个以上换行缩减为1个）