### PR TITLE
feat(签到): 添加签到倒计时提示并简化签到按钮逻辑

### DIFF
--- a/lib/controllers/data.dart
+++ b/lib/controllers/data.dart
@@ -246,47 +246,24 @@ class Controller extends GetxController {
     }
   }
 
-  DateTime? _parseYmd(String? ymd) {
-    if (ymd == null || ymd.isEmpty) return null;
-    final parts = ymd.split('-');
-    if (parts.length != 3) return null;
-    final y = int.tryParse(parts[0]);
-    final m = int.tryParse(parts[1]);
-    final d = int.tryParse(parts[2]);
-    if (y == null || m == null || d == null) return null;
-    return DateTime.utc(y, m, d);
-  }
-
-  DateTime? nextCheckInAt(AuthorModel? u) {
-    final last = _parseYmd(u?.lastCheckInDate);
-    if (last == null) return null;
-    // Business rule: next eligible at next check-in day 00:00 (Asia/Shanghai).
-    // To avoid relying on device timezone, compute in UTC:
-    // 00:00 (UTC+8) == 16:00Z of previous day.
-    final nextDay = last.add(const Duration(days: 1));
-    return DateTime.utc(nextDay.year, nextDay.month, nextDay.day, 16);
-  }
-
-  bool canCheckInNow(AuthorModel? u, {DateTime? now}) {
+  bool canCheckInNow(AuthorModel? _, {DateTime? now}) {
     final t = (now ?? DateTime.now()).toUtc();
     final overrideNext = nextEligibleAtUtc.value;
-    if (overrideNext != null) {
-      return !t.isBefore(overrideNext);
-    }
-    final next = nextCheckInAt(u);
-    if (next == null) return true;
-    return !t.isBefore(next);
+    if (overrideNext == null) return true;
+    return !t.isBefore(overrideNext);
   }
 
-  String? checkInHintText(AuthorModel? u, {DateTime? now}) {
+  String? checkInHintText(AuthorModel? _, {DateTime? now}) {
     final t = (now ?? DateTime.now()).toUtc();
-    final next = nextEligibleAtUtc.value ?? nextCheckInAt(u);
+    final next = nextEligibleAtUtc.value;
     if (next == null || !t.isBefore(next)) return null;
-
-    final diff = next.difference(t);
-    final hours = diff.inHours.toString().padLeft(2, '0');
-    final minutes = diff.inMinutes.remainder(60).toString().padLeft(2, '0');
-    return '预计可签到倒计时 $hours:$minutes';
+    final local = next.toLocal();
+    final y = local.year.toString().padLeft(4, '0');
+    final m = local.month.toString().padLeft(2, '0');
+    final d = local.day.toString().padLeft(2, '0');
+    final hh = local.hour.toString().padLeft(2, '0');
+    final mm = local.minute.toString().padLeft(2, '0');
+    return '预计可签到时间 $y-$m-$d $hh:$mm';
   }
 
   void _loadLocalCaches() {

--- a/lib/controllers/data.dart
+++ b/lib/controllers/data.dart
@@ -260,11 +260,11 @@ class Controller extends GetxController {
   DateTime? nextCheckInAt(AuthorModel? u) {
     final last = _parseYmd(u?.lastCheckInDate);
     if (last == null) return null;
-    // Business rule: next eligible at next check-in day 04:00 (Asia/Shanghai).
+    // Business rule: next eligible at next check-in day 00:00 (Asia/Shanghai).
     // To avoid relying on device timezone, compute in UTC:
-    // 04:00 (UTC+8) == 20:00Z of previous day.
+    // 00:00 (UTC+8) == 16:00Z of previous day.
     final nextDay = last.add(const Duration(days: 1));
-    return DateTime.utc(nextDay.year, nextDay.month, nextDay.day, 20);
+    return DateTime.utc(nextDay.year, nextDay.month, nextDay.day, 16);
   }
 
   bool canCheckInNow(AuthorModel? u, {DateTime? now}) {
@@ -276,6 +276,17 @@ class Controller extends GetxController {
     final next = nextCheckInAt(u);
     if (next == null) return true;
     return !t.isBefore(next);
+  }
+
+  String? checkInHintText(AuthorModel? u, {DateTime? now}) {
+    final t = (now ?? DateTime.now()).toUtc();
+    final next = nextEligibleAtUtc.value ?? nextCheckInAt(u);
+    if (next == null || !t.isBefore(next)) return null;
+
+    final diff = next.difference(t);
+    final hours = diff.inHours.toString().padLeft(2, '0');
+    final minutes = diff.inMinutes.remainder(60).toString().padLeft(2, '0');
+    return '预计可签到倒计时 $hours:$minutes';
   }
 
   void _loadLocalCaches() {


### PR DESCRIPTION
1. **简化签到按钮逻辑**
   - 统一使用 ElevatedButton，不再区分"可签到"/"已签到"两种按钮样式
   - 移除重复的按钮状态管理代码

2. **新增签到提示信息**
   - 在签到按钮下方添加提示文本行
   - 格式：`预计可签到时间 YYYY-MM-DD HH:MM`（本地时区）

3. **重构签到检查机制**
   - 完全依赖后端返回的 `nextEligibleAtUtc` 判断是否可以签到
   - 移除本地日期解析和签到时间计算逻辑（`_parseYmd`、`nextCheckInAt` 方法）

4. **统一错误处理**
   - 409 冲突错误直接提示"今日已签到"