### PR TITLE
feat(评论): 迁移发评论成功后由父页面强制重建评论区功能到v1分支

### DIFF
--- a/lib/api/api.dart
+++ b/lib/api/api.dart
@@ -729,6 +729,43 @@ class Api extends BaseConnect {
     );
   }
 
+  Future<CommentModel?> getCommentDetail(String commentId) async {
+    if (commentId.isEmpty) return null;
+
+    final populateQuery = <String, String>{
+      'populate[0]': 'author',
+      'populate[1]': 'replies',
+      'populate[replies][populate][0]': 'author',
+      'ts': DateTime.now().millisecondsSinceEpoch.toString(),
+    };
+
+    try {
+      final res = await get('/api/comments/$commentId', query: populateQuery);
+      final data = unwrapData<Map<String, dynamic>>(res);
+      return CommentModel.fromJson(data);
+    } catch (_) {
+      // Fallback for deployments where documentId route is disabled.
+    }
+
+    try {
+      final res = await get(
+        '/api/comments',
+        query: {
+          ...populateQuery,
+          'filters[documentId][\$eq]': commentId,
+          'pagination[limit]': '1',
+        },
+      );
+      final list = unwrapData<List<dynamic>>(res);
+      if (list.isEmpty) return null;
+      final first = list.first;
+      if (first is! Map<String, dynamic>) return null;
+      return CommentModel.fromJson(first);
+    } catch (_) {
+      return null;
+    }
+  }
+
   Future<Response<Map<String, dynamic>>> addDiscussionComment(
     String discussionId,
     String body, {

--- a/lib/pages/discussion/discussion_action_buttons.dart
+++ b/lib/pages/discussion/discussion_action_buttons.dart
@@ -7,6 +7,7 @@ import 'package:inter_knot/constants/globals.dart';
 import 'package:inter_knot/controllers/data.dart';
 import 'package:inter_knot/helpers/dialog_helper.dart';
 import 'package:inter_knot/helpers/toast.dart';
+import 'package:inter_knot/models/comment.dart';
 import 'package:inter_knot/models/discussion.dart';
 import 'package:inter_knot/models/h_data.dart';
 import 'package:inter_knot/pages/create_discussion_page.dart';
@@ -130,28 +131,129 @@ class DiscussionActionButtonsState extends State<DiscussionActionButtons>
         }
       }
 
+      final submittedParentId = _parentId;
       _textController.clear();
       _cancel();
 
-      // 清空评论列表并重置分页状态
-      widget.discussion.comments.clear();
-      widget.discussion.commentsCount++;
-      
-      // 强制刷新评论列表
-      await widget.discussion.fetchComments();
-      
-      // 强制刷新UI
-      if (mounted) setState(() {});
-      
+      if (submittedParentId == null) {
+        // 主评论：先更新计数，再按需补齐评论分页，避免新主评论因分页顺序看不到
+        widget.discussion.commentsCount++;
+        await _syncTopLevelCommentsAfterPost();
+      } else {
+        // 楼中楼：重拉当前已加载评论窗口，确保已加载父评论的 replies 被整体刷新
+        await _refreshLoadedCommentsAfterReply(submittedParentId);
+      }
+
       // 通知父组件刷新UI
       widget.onCommentAdded?.call();
-      
+
       showToast('评论发布成功');
     } catch (e) {
       showToast('评论发布失败: $e', isError: true);
     } finally {
       if (mounted) setState(() => _isLoading = false);
     }
+  }
+
+  int _loadedTopLevelCommentCount() {
+    var count = 0;
+    for (final page in widget.discussion.comments) {
+      count += page.nodes.length;
+    }
+    return count;
+  }
+
+  Future<void> _syncTopLevelCommentsAfterPost() async {
+    // 已有分页时，先解锁下一页，确保 hasNextPage=false 时也能继续拉取新数据
+    if (widget.discussion.comments.isNotEmpty) {
+      widget.discussion.comments.last.hasNextPage = true;
+    }
+
+    // 逐页拉取直到本地主评论数量追上最新计数（或到达保护上限）
+    var guard = 0;
+    while (widget.discussion.hasNextPage() &&
+        _loadedTopLevelCommentCount() < widget.discussion.commentsCount &&
+        guard < 20) {
+      await widget.discussion.fetchComments();
+      guard++;
+    }
+
+    // 首次进入帖子且本地还没评论分页时兜底拉一次
+    if (widget.discussion.comments.isEmpty) {
+      await widget.discussion.fetchComments();
+    }
+  }
+
+  Future<void> _reloadCommentsFromStart({
+    required int targetTopLevelCount,
+  }) async {
+    widget.discussion.comments.clear();
+
+    var guard = 0;
+    while (widget.discussion.hasNextPage() &&
+        _loadedTopLevelCommentCount() < targetTopLevelCount &&
+        guard < 20) {
+      await widget.discussion.fetchComments();
+      guard++;
+    }
+
+    if (widget.discussion.comments.isEmpty) {
+      await widget.discussion.fetchComments();
+    }
+  }
+
+  CommentModel? _findLoadedParentComment(String parentId) {
+    for (final page in widget.discussion.comments) {
+      for (final comment in page.nodes) {
+        if (comment.id == parentId) return comment;
+      }
+    }
+    return null;
+  }
+
+  Future<void> _syncParentRepliesAfterReply(String parentId) async {
+    CommentModel? parent = _findLoadedParentComment(parentId);
+
+    // 父评论未加载时先补页到包含该父评论
+    if (parent == null) {
+      if (widget.discussion.comments.isNotEmpty) {
+        widget.discussion.comments.last.hasNextPage = true;
+      }
+      var guard = 0;
+      while (widget.discussion.hasNextPage() &&
+          _findLoadedParentComment(parentId) == null &&
+          guard < 20) {
+        await widget.discussion.fetchComments();
+        guard++;
+      }
+      parent = _findLoadedParentComment(parentId);
+    }
+
+    final latestParent = await api.getCommentDetail(parentId);
+
+    if (parent != null && latestParent != null) {
+      parent.replies
+        ..clear()
+        ..addAll(latestParent.replies);
+      return;
+    }
+
+    // 兜底：无法定向刷新时尝试增量拉取一次主评论列表
+    if (widget.discussion.comments.isNotEmpty) {
+      widget.discussion.comments.last.hasNextPage = true;
+    }
+    await widget.discussion.fetchComments();
+  }
+
+  Future<void> _refreshLoadedCommentsAfterReply(String parentId) async {
+    final loadedBefore = _loadedTopLevelCommentCount();
+
+    // 先尝试定向刷新父评论 replies（轻量）
+    await _syncParentRepliesAfterReply(parentId);
+
+    // 再重拉已加载窗口（强一致），修复 fetchComments 仅追加不更新已加载页的问题
+    final reloadTarget = loadedBefore > 0 ? loadedBefore : 1;
+    await _reloadCommentsFromStart(targetTopLevelCount: reloadTarget);
   }
 
   void _handleTap() async {


### PR DESCRIPTION
- 优化评论发布后的分页同步逻辑
- 添加获取评论详情接口
- 重构评论回复后的刷新逻辑，分为主评论和楼中楼两种场景处理
- 确保评论列表强一致性