### PR TITLE
feat(图片上传): 添加图片格式选择功能并优化压缩逻辑

### DIFF
--- a/lib/helpers/image_compress_helper.dart
+++ b/lib/helpers/image_compress_helper.dart
@@ -1,6 +1,23 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter_image_compress/flutter_image_compress.dart';
 
+enum UploadImageFormat {
+  webp,
+  jpg,
+}
+
+class CompressedImageData {
+  const CompressedImageData({
+    required this.bytes,
+    required this.filename,
+    required this.mimeType,
+  });
+
+  final Uint8List bytes;
+  final String filename;
+  final String mimeType;
+}
+
 /// 上传前自动压缩图片，减少传输体积，提升上传速度。
 /// 支持 Web / Android / iOS / macOS。
 class ImageCompressHelper {
@@ -12,57 +29,149 @@ class ImageCompressHelper {
   /// JPEG 压缩质量 (0-100)
   static const int _quality = 82;
 
-  /// 低于此大小不压缩（200KB）
-  static const int _skipThreshold = 200 * 1024;
-
   /// 压缩图片字节数据
   ///
   /// [bytes] 原始图片二进制
   /// [filename] 文件名，用于判断格式
   /// [mimeType] MIME 类型
   ///
-  /// 返回压缩后的字节数据。如果压缩失败或图片已足够小，返回原始数据。
-  static Future<Uint8List> compress({
+  /// 返回压缩后的字节数据/文件名/MIME。
+  /// - 目标 WebP：先尝试高质量 WebP，再尝试有损 WebP，均不优于原图则回退原图。
+  /// - 目标 JPG：转 JPEG，有损后不优于原图则回退原图。
+  static Future<CompressedImageData> compress({
     required Uint8List bytes,
     required String filename,
-    String mimeType = 'image/jpeg',
+    required String mimeType,
+    required UploadImageFormat targetFormat,
   }) async {
     // GIF 不压缩（会丢失动画）
-    if (_isGif(filename, mimeType)) return bytes;
+    if (_isGif(filename, mimeType)) {
+      return _origin(bytes: bytes, filename: filename, mimeType: mimeType);
+    }
 
-    // 小图不压缩
-    if (bytes.length <= _skipThreshold) return bytes;
+    if (targetFormat == UploadImageFormat.jpg) {
+      return _compressAsJpg(bytes: bytes, filename: filename, mimeType: mimeType);
+    }
+    return _compressAsWebp(bytes: bytes, filename: filename, mimeType: mimeType);
+  }
 
+  static Future<CompressedImageData> _compressAsWebp({
+    required Uint8List bytes,
+    required String filename,
+    required String mimeType,
+  }) async {
+    final losslessLike = await _tryCompress(
+      bytes: bytes,
+      format: CompressFormat.webp,
+      quality: 100,
+    );
+    if (losslessLike != null && losslessLike.length < bytes.length) {
+      debugPrint(
+        '[ImageCompress] WEBP(100) ${bytes.length} -> ${losslessLike.length} bytes',
+      );
+      return CompressedImageData(
+        bytes: Uint8List.fromList(losslessLike),
+        filename: _replaceExtension(filename, 'webp'),
+        mimeType: 'image/webp',
+      );
+    }
+
+    final lossy = await _tryCompress(
+      bytes: bytes,
+      format: CompressFormat.webp,
+      quality: _quality,
+    );
+    if (lossy != null && lossy.length < bytes.length) {
+      debugPrint(
+        '[ImageCompress] WEBP($_quality) ${bytes.length} -> ${lossy.length} bytes',
+      );
+      return CompressedImageData(
+        bytes: Uint8List.fromList(lossy),
+        filename: _replaceExtension(filename, 'webp'),
+        mimeType: 'image/webp',
+      );
+    }
+
+    debugPrint('[ImageCompress] WEBP fallback to original for $filename');
+    return _origin(bytes: bytes, filename: filename, mimeType: mimeType);
+  }
+
+  static Future<CompressedImageData> _compressAsJpg({
+    required Uint8List bytes,
+    required String filename,
+    required String mimeType,
+  }) async {
+    final result = await _tryCompress(
+      bytes: bytes,
+      format: CompressFormat.jpeg,
+      quality: _quality,
+    );
+    if (result != null && result.length < bytes.length) {
+      debugPrint(
+        '[ImageCompress] JPG($_quality) ${bytes.length} -> ${result.length} bytes',
+      );
+      return CompressedImageData(
+        bytes: Uint8List.fromList(result),
+        filename: _replaceExtension(filename, 'jpg'),
+        mimeType: 'image/jpeg',
+      );
+    }
+
+    debugPrint('[ImageCompress] JPG fallback to original for $filename');
+    return _origin(bytes: bytes, filename: filename, mimeType: mimeType);
+  }
+
+  static Future<Uint8List?> _tryCompress({
+    required Uint8List bytes,
+    required CompressFormat format,
+    required int quality,
+  }) async {
     try {
-      final format = _isWebp(filename, mimeType)
-          ? CompressFormat.webp
-          : _isPng(filename, mimeType)
-              ? CompressFormat.png
-              : CompressFormat.jpeg;
-
       final result = await FlutterImageCompress.compressWithList(
         bytes,
         minWidth: _maxDimension,
         minHeight: _maxDimension,
-        quality: _quality,
+        quality: quality,
         format: format,
       );
-
-      // 如果压缩后反而变大，使用原图
-      if (result.length >= bytes.length) {
-        debugPrint(
-            '[ImageCompress] Skipped: compressed ${result.length} >= original ${bytes.length}');
-        return bytes;
-      }
-
-      debugPrint(
-          '[ImageCompress] ${bytes.length} -> ${result.length} bytes '
-          '(${(100 - result.length * 100 ~/ bytes.length)}% saved)');
-      return Uint8List.fromList(result);
+      return result;
     } catch (e) {
-      debugPrint('[ImageCompress] Failed: $e, using original');
-      return bytes;
+      debugPrint('[ImageCompress] Failed: $e');
+      return null;
     }
+  }
+
+  static CompressedImageData _origin({
+    required Uint8List bytes,
+    required String filename,
+    required String mimeType,
+  }) {
+    return CompressedImageData(
+      bytes: bytes,
+      filename: filename,
+      mimeType: _normalizeMimeType(filename: filename, mimeType: mimeType),
+    );
+  }
+
+  static String _replaceExtension(String filename, String newExt) {
+    final dot = filename.lastIndexOf('.');
+    final lowerExt = newExt.toLowerCase();
+    if (dot <= 0 || dot == filename.length - 1) {
+      return '$filename.$lowerExt';
+    }
+    return '${filename.substring(0, dot)}.$lowerExt';
+  }
+
+  static String _normalizeMimeType({
+    required String filename,
+    required String mimeType,
+  }) {
+    final lower = mimeType.toLowerCase();
+    if (lower.startsWith('image/')) return lower;
+    if (_isPng(filename, lower)) return 'image/png';
+    if (_isWebp(filename, lower)) return 'image/webp';
+    if (_isGif(filename, lower)) return 'image/gif';
+    return 'image/jpeg';
   }
 
   static bool _isGif(String filename, String mimeType) =>

--- a/lib/pages/create_discussion/create_discussion_desktop_footer.dart
+++ b/lib/pages/create_discussion/create_discussion_desktop_footer.dart
@@ -1,14 +1,19 @@
 import 'package:flutter/material.dart';
+import 'package:inter_knot/helpers/image_compress_helper.dart';
 
 class CreateDiscussionDesktopFooter extends StatelessWidget {
   const CreateDiscussionDesktopFooter({
     super.key,
     required this.isLoading,
     required this.onSubmit,
+    required this.selectedFormat,
+    required this.onFormatChanged,
   });
 
   final bool isLoading;
   final VoidCallback onSubmit;
+  final UploadImageFormat selectedFormat;
+  final ValueChanged<UploadImageFormat> onFormatChanged;
 
   @override
   Widget build(BuildContext context) {
@@ -24,57 +29,117 @@ class CreateDiscussionDesktopFooter extends StatelessWidget {
         borderRadius: BorderRadius.circular(16),
       ),
       child: Row(
-        mainAxisAlignment: MainAxisAlignment.end,
         children: [
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+            decoration: BoxDecoration(
+              color: const Color(0xff101010),
+              borderRadius: BorderRadius.circular(18),
+              border: Border.all(color: const Color(0xff2E2E2E)),
+            ),
+            child: Row(
+              children: [
+                _FormatButton(
+                  label: 'WebP',
+                  selected: selectedFormat == UploadImageFormat.webp,
+                  onTap: () => onFormatChanged(UploadImageFormat.webp),
+                ),
+                const SizedBox(width: 6),
+                _FormatButton(
+                  label: 'JPG',
+                  selected: selectedFormat == UploadImageFormat.jpg,
+                  onTap: () => onFormatChanged(UploadImageFormat.jpg),
+                ),
+              ],
+            ),
+          ),
+          const Spacer(),
           Material(
             color: const Color(0xff1A1A1A),
             borderRadius: BorderRadius.circular(28),
             child: InkWell(
               borderRadius: BorderRadius.circular(28),
               onTap: isLoading ? null : onSubmit,
-              child: Container(
+              child: SizedBox(
                 height: 56,
-                padding: const EdgeInsets.symmetric(horizontal: 24),
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Container(
-                      padding: const EdgeInsets.all(4),
-                      decoration: const BoxDecoration(
-                        color: Color(0xffFBC02D),
-                        shape: BoxShape.circle,
-                      ),
-                      child: isLoading
-                          ? const SizedBox(
-                              width: 16,
-                              height: 16,
-                              child: CircularProgressIndicator(
-                                strokeWidth: 2,
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 24),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Container(
+                        padding: const EdgeInsets.all(4),
+                        decoration: const BoxDecoration(
+                          color: Color(0xffFBC02D),
+                          shape: BoxShape.circle,
+                        ),
+                        child: isLoading
+                            ? const SizedBox(
+                                width: 16,
+                                height: 16,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                  color: Colors.black,
+                                ),
+                              )
+                            : const Icon(
+                                Icons.send,
                                 color: Colors.black,
+                                size: 16,
                               ),
-                            )
-                          : const Icon(
-                              Icons.send,
-                              color: Colors.black,
-                              size: 16,
-                            ),
-                    ),
-                    const SizedBox(width: 12),
-                    const Text(
-                      '发布',
-                      style: TextStyle(
-                        color: Colors.white,
-                        fontSize: 16,
-                        fontWeight: FontWeight.bold,
-                        letterSpacing: 1,
                       ),
-                    ),
-                  ],
+                      const SizedBox(width: 12),
+                      const Text(
+                        '发布',
+                        style: TextStyle(
+                          color: Colors.white,
+                          fontSize: 16,
+                          fontWeight: FontWeight.bold,
+                          letterSpacing: 1,
+                        ),
+                      ),
+                    ],
+                  ),
                 ),
               ),
             ),
           ),
         ],
+      ),
+    );
+  }
+}
+
+class _FormatButton extends StatelessWidget {
+  const _FormatButton({
+    required this.label,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 120),
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+        decoration: BoxDecoration(
+          color: selected ? const Color(0xffD7FF00) : const Color(0xff1A1A1A),
+          borderRadius: BorderRadius.circular(14),
+        ),
+        child: Text(
+          label,
+          style: TextStyle(
+            color: selected ? Colors.black : const Color(0xffC8C8C8),
+            fontSize: 12,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
       ),
     );
   }

--- a/lib/pages/create_discussion/create_discussion_mobile_nav.dart
+++ b/lib/pages/create_discussion/create_discussion_mobile_nav.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:inter_knot/helpers/image_compress_helper.dart';
 
 class CreateDiscussionMobileNav extends StatelessWidget {
   const CreateDiscussionMobileNav({
@@ -6,6 +7,8 @@ class CreateDiscussionMobileNav extends StatelessWidget {
     required this.isLoading,
     required this.onPickImage,
     required this.onSubmit,
+    required this.selectedFormat,
+    required this.onFormatChanged,
     this.imageCount = 0,
     this.uploadingCount = 0,
   });
@@ -13,6 +16,8 @@ class CreateDiscussionMobileNav extends StatelessWidget {
   final bool isLoading;
   final VoidCallback onPickImage;
   final VoidCallback onSubmit;
+  final UploadImageFormat selectedFormat;
+  final ValueChanged<UploadImageFormat> onFormatChanged;
   final int imageCount;
   final int uploadingCount;
 
@@ -28,15 +33,17 @@ class CreateDiscussionMobileNav extends StatelessWidget {
       ),
       child: Row(
         children: [
-          // Image picker button
           _ToolButton(
             icon: Icons.image_outlined,
             label: imageCount > 0 ? '$imageCount' : null,
             sublabel: uploadingCount > 0 ? '上传中$uploadingCount' : null,
             onTap: onPickImage,
           ),
+          _FormatToggle(
+            selectedFormat: selectedFormat,
+            onChanged: onFormatChanged,
+          ),
           const Spacer(),
-          // Submit button
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
             child: isLoading
@@ -74,6 +81,78 @@ class CreateDiscussionMobileNav extends StatelessWidget {
                   ),
           ),
         ],
+      ),
+    );
+  }
+}
+
+class _FormatToggle extends StatelessWidget {
+  const _FormatToggle({
+    required this.selectedFormat,
+    required this.onChanged,
+  });
+
+  final UploadImageFormat selectedFormat;
+  final ValueChanged<UploadImageFormat> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.symmetric(vertical: 8),
+      padding: const EdgeInsets.all(3),
+      decoration: BoxDecoration(
+        color: const Color(0xff101010),
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(color: const Color(0xff2A2A2A)),
+      ),
+      child: Row(
+        children: [
+          _SmallFormatButton(
+            label: 'WebP',
+            selected: selectedFormat == UploadImageFormat.webp,
+            onTap: () => onChanged(UploadImageFormat.webp),
+          ),
+          _SmallFormatButton(
+            label: 'JPG',
+            selected: selectedFormat == UploadImageFormat.jpg,
+            onTap: () => onChanged(UploadImageFormat.jpg),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SmallFormatButton extends StatelessWidget {
+  const _SmallFormatButton({
+    required this.label,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 120),
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+        decoration: BoxDecoration(
+          color: selected ? const Color(0xffD7FF00) : Colors.transparent,
+          borderRadius: BorderRadius.circular(11),
+        ),
+        child: Text(
+          label,
+          style: TextStyle(
+            fontSize: 11,
+            fontWeight: FontWeight.bold,
+            color: selected ? Colors.black : const Color(0xffA0A0A0),
+          ),
+        ),
       ),
     );
   }

--- a/lib/pages/create_discussion_page.dart
+++ b/lib/pages/create_discussion_page.dart
@@ -62,6 +62,7 @@ class _CreateDiscussionPageState extends State<CreateDiscussionPage> {
   // Images State — each image is tracked as an UploadTask with its own status/progress
   final RxList<UploadTask> _uploadTasks = <UploadTask>[].obs;
   bool _isDragging = false;  // 拖拽状态
+  UploadImageFormat _imageUploadFormat = UploadImageFormat.webp;
 
   // 压缩是 CPU 密集型任务：限制并发，避免 UI 卡顿（Web 单线程更明显）
   final Queue<Completer<void>> _compressionWaiters = Queue<Completer<void>>();
@@ -183,7 +184,7 @@ class _CreateDiscussionPageState extends State<CreateDiscussionPage> {
     try {
       // 1. 压缩阶段（限流，防止多图并发压缩导致 UI 卡死）
       await _acquireCompressionSlot();
-      final Uint8List compressed;
+      final CompressedImageData compressed;
       try {
         task.status.value = UploadStatus.compressing;
         task.progress.value = 0;
@@ -196,21 +197,22 @@ class _CreateDiscussionPageState extends State<CreateDiscussionPage> {
           bytes: task.bytes,
           filename: task.filename,
           mimeType: task.mimeType,
+          targetFormat: _imageUploadFormat,
         );
       } finally {
         _releaseCompressionSlot();
       }
-      task.bytes = compressed;
 
       // 2. 上传阶段
       task.status.value = UploadStatus.uploading;
       task.progress.value = 0;
       _uploadTasks.refresh();
 
-      final result = await api.uploadImage(
-        bytes: compressed,
-        filename: task.filename,
-        mimeType: task.mimeType,
+      final result = await _uploadImageWithFallback(
+        originalBytes: task.bytes,
+        originalFilename: task.filename,
+        originalMimeType: task.mimeType,
+        compressed: compressed,
         onProgress: (percent) {
           task.progress.value = percent;
         },
@@ -307,7 +309,7 @@ class _CreateDiscussionPageState extends State<CreateDiscussionPage> {
     try {
       // 压缩图片后再上传
       await _acquireCompressionSlot();
-      final Uint8List compressed;
+      final CompressedImageData compressed;
       try {
         // 给 UI 一个渲染帧，避免主线程长任务造成“假死感”
         await Future<void>.delayed(const Duration(milliseconds: 16));
@@ -315,15 +317,17 @@ class _CreateDiscussionPageState extends State<CreateDiscussionPage> {
           bytes: bytes,
           filename: filename,
           mimeType: mimeType,
+          targetFormat: _imageUploadFormat,
         );
       } finally {
         _releaseCompressionSlot();
       }
 
-      final result = await api.uploadImage(
-        bytes: compressed,
-        filename: filename,
-        mimeType: mimeType,
+      final result = await _uploadImageWithFallback(
+        originalBytes: bytes,
+        originalFilename: filename,
+        originalMimeType: mimeType,
+        compressed: compressed,
         onProgress: (_) {},
       );
 
@@ -346,6 +350,41 @@ class _CreateDiscussionPageState extends State<CreateDiscussionPage> {
       _replaceTokenWithImage(token, fullUrl);
     } catch (e) {
       _replaceToken(token, '上传失败：$filename ($e)');
+    }
+  }
+
+  Future<Map<String, dynamic>?> _uploadImageWithFallback({
+    required Uint8List originalBytes,
+    required String originalFilename,
+    required String originalMimeType,
+    required CompressedImageData compressed,
+    required void Function(int percent) onProgress,
+  }) async {
+    try {
+      return await api.uploadImage(
+        bytes: compressed.bytes,
+        filename: compressed.filename,
+        mimeType: compressed.mimeType,
+        onProgress: onProgress,
+      );
+    } catch (e) {
+      final changed = compressed.filename != originalFilename ||
+          compressed.mimeType != originalMimeType ||
+          compressed.bytes.length != originalBytes.length;
+      if (!changed) rethrow;
+
+      debugPrint(
+        'Compressed upload failed, fallback to original. '
+        'compressed=${compressed.filename}/${compressed.mimeType}/${compressed.bytes.length}, '
+        'original=$originalFilename/$originalMimeType/${originalBytes.length}, err=$e',
+      );
+
+      return api.uploadImage(
+        bytes: originalBytes,
+        filename: originalFilename,
+        mimeType: originalMimeType,
+        onProgress: onProgress,
+      );
     }
   }
 
@@ -684,28 +723,83 @@ class _CreateDiscussionPageState extends State<CreateDiscussionPage> {
         );
       } else {
         // Create Mode
-        var slug = _slugify(title);
+        final baseSlug = _slugify(title);
+        var slug = baseSlug == 'post' ? _slugifyUnique(title) : baseSlug;
         final user = c.user.value;
         final authorId = c.authorId.value ?? await c.ensureAuthorForUser(user);
         if (authorId == null || authorId.isEmpty) {
           throw Exception('无法关联作者，请重新登录后再试');
         }
 
+        dynamic currentCoverId = finalCoverId;
         final captchaService = Get.find<CaptchaService>();
         Future<Response<Map<String, dynamic>>> submitArticle({
           CaptchaPayload? captcha,
+          bool withAuthor = true,
         }) {
           return api.createArticle(
             title: title,
             text: markdownText,
             slug: slug,
-            coverId: finalCoverId,
-            authorId: authorId,
+            coverId: currentCoverId,
+            authorId: withAuthor ? authorId : null,
             captcha: captcha,
           );
         }
 
         res = await submitArticle();
+
+        final firstError = res.body?['error'];
+        final firstErrorCode = firstError is Map
+            ? firstError['code']?.toString()
+            : null;
+        if (firstErrorCode == 'PolicyError') {
+          debugPrint(
+            '[CreateArticle] PolicyError. '
+            'slug=$slug, authorId=$authorId, coverType=${finalCoverId.runtimeType}, '
+            'coverCount=${currentCoverId is List ? currentCoverId.length : (currentCoverId == null ? 0 : 1)}, '
+            'textHasWebp=${markdownText.toLowerCase().contains(".webp")}',
+          );
+        }
+
+        // Some backend policies only accept one cover relation.
+        if (firstErrorCode == 'PolicyError' &&
+            currentCoverId is List &&
+            currentCoverId.isNotEmpty) {
+          final firstCover = currentCoverId.first;
+          currentCoverId = firstCover;
+          debugPrint(
+            '[CreateArticle] Retry with single cover due to PolicyError: $firstCover',
+          );
+          res = await submitArticle();
+        }
+
+        final secondError = res.body?['error'];
+        final secondErrorCode = secondError is Map
+            ? secondError['code']?.toString()
+            : null;
+        // Some policies disallow explicit author in payload.
+        if (secondErrorCode == 'PolicyError') {
+          debugPrint(
+            '[CreateArticle] Retry without author due to PolicyError. authorId=$authorId',
+          );
+          res = await submitArticle(withAuthor: false);
+        }
+
+        final thirdError = res.body?['error'];
+        final thirdErrorCode = thirdError is Map
+            ? thirdError['code']?.toString()
+            : null;
+        if (thirdErrorCode == 'PolicyError') {
+          final uniqueSlug = _slugifyUnique(title);
+          if (uniqueSlug != slug) {
+            slug = uniqueSlug;
+            debugPrint(
+              '[CreateArticle] Retry with unique slug due to PolicyError: $slug',
+            );
+            res = await submitArticle();
+          }
+        }
 
         // Check for error in REST format (error object) or GraphQL format (errors list)
         final resBody = res.body;
@@ -747,18 +841,24 @@ class _CreateDiscussionPageState extends State<CreateDiscussionPage> {
         // Try to extract Strapi error message
         final errorBody = res.body;
         String? msg;
+        String? errCode;
         if (errorBody != null) {
           final error = errorBody['error'];
           final errors = errorBody['errors'];
           if (error is Map) {
             msg = CaptchaService.resolveErrorMessageFromBody(errorBody) ??
                 error['message']?.toString();
+            errCode = error['code']?.toString();
           } else if (errors is List && errors.isNotEmpty) {
             final first = errors.first;
             if (first is Map) {
               msg = first['message']?.toString();
             }
           }
+        }
+        if (errCode == 'PolicyError' &&
+            _imageUploadFormat == UploadImageFormat.webp) {
+          throw Exception('后端策略拒绝当前内容（PolicyError）。请切换为 JPG 后重新上传图片再发布。');
         }
         throw Exception(msg ?? res.statusText ?? 'Unknown error');
       }
@@ -865,6 +965,12 @@ class _CreateDiscussionPageState extends State<CreateDiscussionPage> {
                 isLoading: isLoading,
                 onPickImage: _pickImages,
                 onSubmit: () => _submit(isMobile: true),
+                selectedFormat: _imageUploadFormat,
+                onFormatChanged: (value) {
+                  setState(() {
+                    _imageUploadFormat = value;
+                  });
+                },
                 imageCount: _uploadTasks.length,
                 uploadingCount: _uploadTasks
                     .where((t) =>
@@ -916,6 +1022,12 @@ class _CreateDiscussionPageState extends State<CreateDiscussionPage> {
                               CreateDiscussionDesktopFooter(
                                 isLoading: isLoading,
                                 onSubmit: _submit,
+                                selectedFormat: _imageUploadFormat,
+                                onFormatChanged: (value) {
+                                  setState(() {
+                                    _imageUploadFormat = value;
+                                  });
+                                },
                               ),
                             ],
                           ),


### PR DESCRIPTION
添加 WebP 和 JPG 格式选择功能，允许用户在发布前选择图片上传格式
重构图片压缩逻辑，支持多种压缩策略和格式转换
优化上传失败处理，增加格式回退机制
在移动端和桌面端添加格式选择 UI 组件
处理后端策略错误，提供更友好的错误提示