### PR TITLE
feat(编辑器): 添加Ctrl+点击链接打开功能

### DIFF
--- a/lib/pages/create_discussion/create_discussion_editor_page.dart
+++ b/lib/pages/create_discussion/create_discussion_editor_page.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_quill/flutter_quill.dart' as quill;
 import 'package:flutter_quill_extensions/flutter_quill_extensions.dart';
 import 'package:get/get.dart';
 import 'package:inter_knot/components/image_viewer.dart';
 import 'package:inter_knot/helpers/upload_task.dart';
+import 'package:url_launcher/url_launcher_string.dart';
 
 class CreateDiscussionEditorPage extends StatelessWidget {
   const CreateDiscussionEditorPage({
@@ -28,6 +30,17 @@ class CreateDiscussionEditorPage extends StatelessWidget {
   final RxList<UploadTask>? mobileUploadTasks;
   final void Function(int index)? onRemoveMobileImage;
   final void Function(UploadTask task)? onRetryMobileImage;
+
+  bool _isCtrlPressed() {
+    final keys = HardwareKeyboard.instance.logicalKeysPressed;
+    return keys.contains(LogicalKeyboardKey.controlLeft) ||
+        keys.contains(LogicalKeyboardKey.controlRight);
+  }
+
+  Future<void> _handleLaunchUrl(String url) async {
+    if (!_isCtrlPressed()) return;
+    await launchUrlString(url);
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -84,6 +97,7 @@ class CreateDiscussionEditorPage extends StatelessWidget {
               config: quill.QuillEditorConfig(
                 placeholder: '请输入文本',
                 padding: const EdgeInsets.all(16),
+                onLaunchUrl: _handleLaunchUrl,
                 embedBuilders: [
                   ...FlutterQuillEmbeds.editorBuilders(
                     imageEmbedConfig: QuillEditorImageEmbedConfig(


### PR DESCRIPTION
在讨论编辑器页面添加通过Ctrl+点击打开链接的功能。引入url_launcher_string包处理URL打开，并添加键盘控制检测逻辑。