### PR TITLE
[重要！！！]refactor(编辑器): 替换富文本编辑器为纯Markdown输入实现

### DIFF
--- a/lib/helpers/normalize_markdown.dart
+++ b/lib/helpers/normalize_markdown.dart
@@ -22,10 +22,5 @@ String normalizeMarkdown(String input) {
     RegExp(r'!\[([^\]]*)\]\(([^)\s]+)\)\s*\)+(?=\s|$)'),
     (m) => '![${m[1]}](${m[2]})',
   );
-  // Remove extra newlines added by DeltaToMarkdown (2 newlines -> 1).
-  out = out.replaceAllMapped(
-    RegExp(r'\n{2,}'),
-    (m) => '\n' * ((m[0]!.length + 1) ~/ 2),
-  );
   return out;
 }

--- a/lib/helpers/prepare_markdown_for_display.dart
+++ b/lib/helpers/prepare_markdown_for_display.dart
@@ -1,0 +1,44 @@
+String prepareMarkdownForDisplay(String input) {
+  const blankLinePlaceholder = '\u200B';
+  final lines = input.replaceAll('\r\n', '\n').split('\n');
+  final output = <String>[];
+  var blankLineCount = 0;
+  var inFence = false;
+
+  void flushBlankLines() {
+    if (blankLineCount == 0) return;
+    output.add('');
+    for (var i = 1; i < blankLineCount; i++) {
+      output.add(blankLinePlaceholder);
+      output.add('');
+    }
+    blankLineCount = 0;
+  }
+
+  for (final line in lines) {
+    final trimmed = line.trimLeft();
+    final isFenceDelimiter =
+        trimmed.startsWith('```') || trimmed.startsWith('~~~');
+
+    if (!inFence && line.isEmpty) {
+      blankLineCount++;
+      continue;
+    }
+
+    if (!inFence) {
+      flushBlankLines();
+    }
+
+    output.add(line);
+
+    if (isFenceDelimiter) {
+      inFence = !inFence;
+    }
+  }
+
+  if (!inFence) {
+    flushBlankLines();
+  }
+
+  return output.join('\n');
+}

--- a/lib/models/discussion.dart
+++ b/lib/models/discussion.dart
@@ -129,7 +129,7 @@ DiscussionModel parseDiscussionData(Map<String, dynamic> json) {
     bodyHTML: html,
     bodyText: bodyText,
     coverImages: covers,
-    rawBodyText: normalized,
+    rawBodyText: rawBody,
     // number: ... Removed
     id: json['documentId'] as String? ??
         json['id']?.toString() ??

--- a/lib/pages/create_discussion/create_discussion_editor_page.dart
+++ b/lib/pages/create_discussion/create_discussion_editor_page.dart
@@ -1,6 +1,7 @@
+import 'dart:ui';
+
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_quill/flutter_quill.dart' as quill;
-import 'package:flutter_quill_extensions/flutter_quill_extensions.dart';
 import 'package:get/get.dart';
 import 'package:inter_knot/components/image_viewer.dart';
 import 'package:inter_knot/helpers/upload_task.dart';
@@ -9,22 +10,20 @@ class CreateDiscussionEditorPage extends StatelessWidget {
   const CreateDiscussionEditorPage({
     super.key,
     required this.titleController,
-    required this.quillController,
+    required this.bodyController,
     required this.onPickAndUploadImage,
     this.isMobile = false,
-    this.mobileBodyController,
     this.mobileUploadTasks,
     this.onRemoveMobileImage,
     this.onRetryMobileImage,
   });
 
   final TextEditingController titleController;
-  final quill.QuillController quillController;
+  final TextEditingController bodyController;
   final VoidCallback onPickAndUploadImage;
 
   // Mobile-only
   final bool isMobile;
-  final TextEditingController? mobileBodyController;
   final RxList<UploadTask>? mobileUploadTasks;
   final void Function(int index)? onRemoveMobileImage;
   final void Function(UploadTask task)? onRetryMobileImage;
@@ -34,64 +33,531 @@ class CreateDiscussionEditorPage extends StatelessWidget {
     if (isMobile) {
       return _MobileEditorBody(
         titleController: titleController,
-        bodyController: mobileBodyController!,
+        bodyController: bodyController,
         uploadTasks: mobileUploadTasks!,
         onRemoveImage: onRemoveMobileImage!,
         onRetryImage: onRetryMobileImage!,
       );
     }
 
-    // ── Desktop: Quill editor ──
+    return _DesktopEditorBody(
+      titleController: titleController,
+      bodyController: bodyController,
+      onPickAndUploadImage: onPickAndUploadImage,
+    );
+  }
+}
+
+class _DesktopEditorBody extends StatefulWidget {
+  const _DesktopEditorBody({
+    required this.titleController,
+    required this.bodyController,
+    required this.onPickAndUploadImage,
+  });
+
+  final TextEditingController titleController;
+  final TextEditingController bodyController;
+  final VoidCallback onPickAndUploadImage;
+
+  @override
+  State<_DesktopEditorBody> createState() => _DesktopEditorBodyState();
+}
+
+class _DesktopEditorBodyState extends State<_DesktopEditorBody> {
+  final _titleFocus = FocusNode();
+  final _bodyFocus = FocusNode();
+  final _toolbarScrollController = ScrollController();
+  final _undoController = UndoHistoryController();
+  bool _showToolbarScrollbar = false;
+
+  @override
+  void dispose() {
+    _toolbarScrollController.dispose();
+    _undoController.dispose();
+    _titleFocus.dispose();
+    _bodyFocus.dispose();
+    super.dispose();
+  }
+
+  TextSelection get _selection {
+    final selection = widget.bodyController.selection;
+    if (!selection.isValid) {
+      final offset = widget.bodyController.text.length;
+      return TextSelection.collapsed(offset: offset);
+    }
+    return selection;
+  }
+
+  void _updateText(
+    String newText, {
+    required int selectionStart,
+    required int selectionEnd,
+  }) {
+    widget.bodyController.value = TextEditingValue(
+      text: newText,
+      selection: TextSelection(
+        baseOffset: selectionStart,
+        extentOffset: selectionEnd,
+      ),
+    );
+    _bodyFocus.requestFocus();
+  }
+
+  void _replaceSelection({
+    required String replacement,
+    int? selectionStart,
+    int? selectionEnd,
+  }) {
+    final selection = _selection;
+    final text = widget.bodyController.text;
+    final start = selection.start;
+    final end = selection.end;
+    final newText = text.replaceRange(start, end, replacement);
+    final nextStart = selectionStart ?? start + replacement.length;
+    final nextEnd = selectionEnd ?? nextStart;
+    _updateText(
+      newText,
+      selectionStart: nextStart,
+      selectionEnd: nextEnd,
+    );
+  }
+
+  void _wrapSelection(String before, String after, {String placeholder = ''}) {
+    final selection = _selection;
+    final selected = selection.textInside(widget.bodyController.text);
+    final content = selected.isEmpty ? placeholder : selected;
+    final replacement = '$before$content$after';
+    final cursorStart = selection.start + before.length;
+    _replaceSelection(
+      replacement: replacement,
+      selectionStart: cursorStart,
+      selectionEnd: cursorStart + content.length,
+    );
+  }
+
+  ({int start, int end}) _selectedLineRange() {
+    final text = widget.bodyController.text;
+    final selection = _selection;
+    var start = selection.start;
+    var end = selection.end;
+    while (start > 0 && text[start - 1] != '\n') {
+      start--;
+    }
+    while (end < text.length && text[end] != '\n') {
+      end++;
+    }
+    return (start: start, end: end);
+  }
+
+  void _transformSelectedLines(List<String> Function(List<String> lines) transform) {
+    final range = _selectedLineRange();
+    final original = widget.bodyController.text.substring(range.start, range.end);
+    final lines = original.split('\n');
+    final updatedLines = transform(lines);
+    final replacement = updatedLines.join('\n');
+    final text = widget.bodyController.text.replaceRange(
+      range.start,
+      range.end,
+      replacement,
+    );
+    _updateText(
+      text,
+      selectionStart: range.start,
+      selectionEnd: range.start + replacement.length,
+    );
+  }
+
+  void _toggleSymmetricMarker(String marker) {
+    final selection = _selection;
+    final text = widget.bodyController.text;
+    final selected = selection.textInside(text);
+    final hasMarker =
+        selected.startsWith(marker) && selected.endsWith(marker) &&
+        selected.length >= marker.length * 2;
+    if (hasMarker) {
+      final unwrapped =
+          selected.substring(marker.length, selected.length - marker.length);
+      _replaceSelection(
+        replacement: unwrapped,
+        selectionStart: selection.start,
+        selectionEnd: selection.start + unwrapped.length,
+      );
+      return;
+    }
+    _wrapSelection(marker, marker, placeholder: '文本');
+  }
+
+  void _applyHeading(String prefix) {
+    _transformSelectedLines((lines) {
+      return lines.map((line) {
+        final withoutHeading = line.replaceFirst(RegExp(r'^\s{0,3}#{1,6}\s+'), '');
+        if (prefix.isEmpty) return withoutHeading;
+        return '$prefix$withoutHeading';
+      }).toList();
+    });
+  }
+
+  void _toggleFixedPrefix(String prefix) {
+    _transformSelectedLines((lines) {
+      final allPrefixed = lines.where((line) => line.isNotEmpty).isNotEmpty &&
+          lines.where((line) => line.isNotEmpty).every((line) => line.startsWith(prefix));
+      return lines.map((line) {
+        if (line.isEmpty) return line;
+        if (allPrefixed) {
+          return line.startsWith(prefix) ? line.substring(prefix.length) : line;
+        }
+        return '$prefix$line';
+      }).toList();
+    });
+  }
+
+  void _toggleOrderedList() {
+    _transformSelectedLines((lines) {
+      final nonEmpty = lines.where((line) => line.isNotEmpty).toList();
+      final allOrdered = nonEmpty.isNotEmpty &&
+          nonEmpty.every((line) => RegExp(r'^\d+\.\s').hasMatch(line));
+      var index = 1;
+      return lines.map((line) {
+        if (line.isEmpty) return line;
+        if (allOrdered) {
+          return line.replaceFirst(RegExp(r'^\d+\.\s'), '');
+        }
+        final stripped = line.replaceFirst(RegExp(r'^\d+\.\s'), '');
+        return '${index++}. $stripped';
+      }).toList();
+    });
+  }
+
+  void _toggleTaskList() {
+    _transformSelectedLines((lines) {
+      final nonEmpty = lines.where((line) => line.isNotEmpty).toList();
+      final allTask = nonEmpty.isNotEmpty &&
+          nonEmpty.every((line) => line.startsWith('- [ ] '));
+      return lines.map((line) {
+        if (line.isEmpty) return line;
+        if (allTask) {
+          return line.replaceFirst('- [ ] ', '');
+        }
+        return '- [ ] $line';
+      }).toList();
+    });
+  }
+
+  void _adjustIndent(bool increase) {
+    _transformSelectedLines((lines) {
+      return lines.map((line) {
+        if (line.isEmpty) return line;
+        if (increase) return '  $line';
+        if (line.startsWith('  ')) return line.substring(2);
+        if (line.startsWith('\t')) return line.substring(1);
+        return line;
+      }).toList();
+    });
+  }
+
+  void _insertCodeBlock() {
+    final selection = _selection;
+    final selected = selection.textInside(widget.bodyController.text);
+    final content = selected.isEmpty ? '代码' : selected;
+    final replacement = '```\n$content\n```';
+    _replaceSelection(
+      replacement: replacement,
+      selectionStart: selection.start + 4,
+      selectionEnd: selection.start + 4 + content.length,
+    );
+  }
+
+  void _clearFormatting() {
+    final selection = _selection;
+    final selected = selection.textInside(widget.bodyController.text);
+    if (selected.isNotEmpty) {
+      var cleaned = selected;
+      cleaned = cleaned.replaceAllMapped(
+        RegExp(r'(\*\*|__|~~|`)(.*?)\1', dotAll: true),
+        (m) => m[2] ?? '',
+      );
+      cleaned = cleaned.replaceAllMapped(
+        RegExp(r'\[(.*?)\]\((.*?)\)', dotAll: true),
+        (m) => m[1] ?? '',
+      );
+      _replaceSelection(
+        replacement: cleaned,
+        selectionStart: selection.start,
+        selectionEnd: selection.start + cleaned.length,
+      );
+      return;
+    }
+
+    _transformSelectedLines((lines) {
+      return lines.map((line) {
+        var cleaned = line;
+        cleaned = cleaned.replaceFirst(RegExp(r'^\s{0,3}#{1,6}\s+'), '');
+        cleaned = cleaned.replaceFirst(RegExp(r'^\d+\.\s'), '');
+        cleaned = cleaned.replaceFirst(RegExp(r'^[-*+]\s'), '');
+        cleaned = cleaned.replaceFirst(RegExp(r'^- \[ \]\s'), '');
+        cleaned = cleaned.replaceFirst(RegExp(r'^>\s?'), '');
+        cleaned = cleaned.replaceFirst(RegExp(r'^(  |\t)+'), '');
+        return cleaned;
+      }).toList();
+    });
+  }
+
+  Widget _toolbarButton({
+    required String tooltip,
+    required IconData icon,
+    required VoidCallback? onPressed,
+  }) {
+    return Tooltip(
+      message: tooltip,
+      child: IconButton(
+        onPressed: onPressed,
+        icon: Icon(icon, size: 18),
+        style: IconButton.styleFrom(
+          backgroundColor: const Color(0xff151515),
+          foregroundColor: Colors.white,
+          disabledBackgroundColor: const Color(0xff151515),
+          disabledForegroundColor: Colors.white24,
+          hoverColor: const Color(0xff2A2A2A),
+          minimumSize: const Size(36, 36),
+          maximumSize: const Size(36, 36),
+          padding: EdgeInsets.zero,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(4),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildToolbar() {
+    final items = <Widget>[
+        ValueListenableBuilder<UndoHistoryValue>(
+          valueListenable: _undoController,
+          builder: (context, value, child) {
+            return _toolbarButton(
+              tooltip: '撤销',
+              icon: Icons.undo,
+              onPressed: value.canUndo ? _undoController.undo : null,
+            );
+          },
+        ),
+        ValueListenableBuilder<UndoHistoryValue>(
+          valueListenable: _undoController,
+          builder: (context, value, child) {
+            return _toolbarButton(
+              tooltip: '重做',
+              icon: Icons.redo,
+              onPressed: value.canRedo ? _undoController.redo : null,
+            );
+          },
+        ),
+        _toolbarButton(
+          tooltip: '粗体',
+          icon: Icons.format_bold,
+          onPressed: () => _toggleSymmetricMarker('**'),
+        ),
+        _toolbarButton(
+          tooltip: '斜体',
+          icon: Icons.format_italic,
+          onPressed: () => _toggleSymmetricMarker('*'),
+        ),
+        _toolbarButton(
+          tooltip: '下划线',
+          icon: Icons.format_underlined,
+          onPressed: () => _wrapSelection('<u>', '</u>', placeholder: '文本'),
+        ),
+        _toolbarButton(
+          tooltip: '删除线',
+          icon: Icons.format_strikethrough,
+          onPressed: () => _toggleSymmetricMarker('~~'),
+        ),
+        _toolbarButton(
+          tooltip: '内嵌代码',
+          icon: Icons.code,
+          onPressed: () => _toggleSymmetricMarker('`'),
+        ),
+        _toolbarButton(
+          tooltip: '清除格式',
+          icon: Icons.format_clear,
+          onPressed: _clearFormatting,
+        ),
+        PopupMenuButton<String>(
+          tooltip: '标题样式',
+          color: const Color(0xff1A1A1A),
+          onSelected: _applyHeading,
+          itemBuilder: (context) => const [
+            PopupMenuItem(value: '', child: Text('正文')),
+            PopupMenuItem(value: '# ', child: Text('标题 1')),
+            PopupMenuItem(value: '## ', child: Text('标题 2')),
+            PopupMenuItem(value: '### ', child: Text('标题 3')),
+          ],
+          child: Container(
+            width: 36,
+            height: 36,
+            decoration: BoxDecoration(
+              color: const Color(0xff151515),
+              borderRadius: BorderRadius.circular(4),
+            ),
+            child: const Icon(Icons.title, size: 18, color: Colors.white),
+          ),
+        ),
+        _toolbarButton(
+          tooltip: '有序列表',
+          icon: Icons.format_list_numbered,
+          onPressed: _toggleOrderedList,
+        ),
+        _toolbarButton(
+          tooltip: '无序列表',
+          icon: Icons.format_list_bulleted,
+          onPressed: () => _toggleFixedPrefix('- '),
+        ),
+        _toolbarButton(
+          tooltip: '任务列表',
+          icon: Icons.checklist,
+          onPressed: _toggleTaskList,
+        ),
+        _toolbarButton(
+          tooltip: '代码块',
+          icon: Icons.data_object,
+          onPressed: _insertCodeBlock,
+        ),
+        _toolbarButton(
+          tooltip: '引言',
+          icon: Icons.format_quote,
+          onPressed: () => _toggleFixedPrefix('> '),
+        ),
+        _toolbarButton(
+          tooltip: '增加缩进',
+          icon: Icons.format_indent_increase,
+          onPressed: () => _adjustIndent(true),
+        ),
+        _toolbarButton(
+          tooltip: '减少缩进',
+          icon: Icons.format_indent_decrease,
+          onPressed: () => _adjustIndent(false),
+        ),
+        _toolbarButton(
+          tooltip: '插入链接',
+          icon: Icons.link,
+          onPressed: () => _wrapSelection('[', '](https://)', placeholder: '链接文字'),
+        ),
+        _toolbarButton(
+          tooltip: '插入图片',
+          icon: Icons.image_outlined,
+          onPressed: widget.onPickAndUploadImage,
+        ),
+      ];
+
+    return Container(
+      padding: const EdgeInsets.all(8),
+      decoration: BoxDecoration(
+        color: const Color(0xff0F0F0F),
+        border: Border.all(color: Colors.grey.withValues(alpha: 0.5)),
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: ScrollConfiguration(
+        behavior: const MaterialScrollBehavior().copyWith(
+          dragDevices: {
+            PointerDeviceKind.touch,
+            PointerDeviceKind.mouse,
+            PointerDeviceKind.trackpad,
+          },
+        ),
+        child: MouseRegion(
+          onEnter: (_) => setState(() => _showToolbarScrollbar = true),
+          onExit: (_) => setState(() => _showToolbarScrollbar = false),
+          child: Listener(
+            onPointerSignal: (event) {
+              if (event is! PointerScrollEvent ||
+                  !_toolbarScrollController.hasClients) {
+                return;
+              }
+              final nextOffset = (_toolbarScrollController.offset +
+                      event.scrollDelta.dy +
+                      event.scrollDelta.dx)
+                  .clamp(
+                    0.0,
+                    _toolbarScrollController.position.maxScrollExtent,
+                  );
+              _toolbarScrollController.jumpTo(nextOffset);
+            },
+            child: Scrollbar(
+              controller: _toolbarScrollController,
+              thumbVisibility: _showToolbarScrollbar,
+              interactive: true,
+              notificationPredicate: (notification) => notification.depth == 0,
+              child: SingleChildScrollView(
+                controller: _toolbarScrollController,
+                scrollDirection: Axis.horizontal,
+                child: Row(
+                  children: [
+                    for (var i = 0; i < items.length; i++) ...[
+                      items[i],
+                      if (i != items.length - 1) const SizedBox(width: 8),
+                    ],
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
     return Column(
       children: [
         TextField(
-          controller: titleController,
+          controller: widget.titleController,
+          focusNode: _titleFocus,
+          maxLines: 1,
+          style: const TextStyle(color: Colors.white),
           decoration: const InputDecoration(
             hintText: '标题',
             border: OutlineInputBorder(),
           ),
         ),
         const SizedBox(height: 16),
-        quill.QuillSimpleToolbar(
-          controller: quillController,
-          config: quill.QuillSimpleToolbarConfig(
-            showFontFamily: false,
-            showFontSize: false,
-            showSearchButton: false,
-            showSubscript: false,
-            showSuperscript: false,
-            showColorButton: false,
-            showBackgroundColorButton: false,
-            toolbarIconAlignment: WrapAlignment.start,
-            multiRowsDisplay: false,
-            customButtons: [
-              quill.QuillToolbarCustomButtonOptions(
-                icon: const Icon(Icons.image),
-                onPressed: onPickAndUploadImage,
-              ),
+        Padding(
+          padding: const EdgeInsets.only(bottom: 8),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              _buildToolbar(),
             ],
           ),
         ),
-        const SizedBox(height: 8),
         Expanded(
           child: Container(
             decoration: BoxDecoration(
               border: Border.all(color: Colors.grey.withValues(alpha: 0.5)),
               borderRadius: BorderRadius.circular(4),
             ),
-            child: quill.QuillEditor.basic(
-              controller: quillController,
-              config: quill.QuillEditorConfig(
-                placeholder: '请输入文本',
-                padding: const EdgeInsets.all(16),
-                embedBuilders: [
-                  ...FlutterQuillEmbeds.editorBuilders(
-                    imageEmbedConfig: QuillEditorImageEmbedConfig(
-                      onImageClicked: (url) {},
-                    ),
-                  ),
-                  const _DividerEmbedBuilder(),
-                ],
+            child: TextField(
+              controller: widget.bodyController,
+              focusNode: _bodyFocus,
+              maxLines: null,
+              expands: true,
+              keyboardType: TextInputType.multiline,
+              textAlignVertical: TextAlignVertical.top,
+              undoController: _undoController,
+              mouseCursor: SystemMouseCursors.text,
+              style: const TextStyle(
+                fontSize: 16,
+                color: Color(0xffE0E0E0),
+                height: 1.7,
+              ),
+              decoration: const InputDecoration(
+                hintText: '说点什么吧...\n\n支持 Markdown，例如：\n# 标题\n- 列表\n![图片](url)',
+                hintStyle: TextStyle(
+                  fontSize: 16,
+                  color: Color(0xff505050),
+                  height: 1.6,
+                ),
+                border: InputBorder.none,
+                contentPadding: EdgeInsets.all(16),
               ),
             ),
           ),
@@ -408,24 +874,5 @@ class _MobileImageTile extends StatelessWidget {
       case UploadStatus.done:
         return const SizedBox.shrink();
     }
-  }
-}
-
-class _DividerEmbedBuilder extends quill.EmbedBuilder {
-  const _DividerEmbedBuilder();
-
-  @override
-  String get key => 'divider';
-
-  @override
-  Widget build(BuildContext context, quill.EmbedContext embedContext) {
-    return const Padding(
-      padding: EdgeInsets.symmetric(vertical: 8),
-      child: Divider(
-        height: 1,
-        thickness: 1,
-        color: Color(0xff313132),
-      ),
-    );
   }
 }

--- a/lib/pages/create_discussion_page.dart
+++ b/lib/pages/create_discussion_page.dart
@@ -4,7 +4,6 @@ import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_quill/flutter_quill.dart' as quill;
 import 'package:get/get.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:inter_knot/api/api.dart';
@@ -12,12 +11,10 @@ import 'package:inter_knot/controllers/data.dart';
 import 'package:inter_knot/helpers/dialog_helper.dart';
 import 'package:inter_knot/helpers/drop_zone.dart';
 import 'package:inter_knot/helpers/image_compress_helper.dart';
-import 'package:inter_knot/helpers/normalize_markdown.dart';
 import 'package:inter_knot/helpers/toast.dart';
 import 'package:inter_knot/helpers/upload_task.dart';
 import 'package:inter_knot/helpers/web_hooks.dart';
 import 'package:inter_knot/models/captcha.dart';
-import 'package:markdown_quill/markdown_quill.dart';
 
 import 'package:inter_knot/pages/create_discussion/create_discussion_desktop_footer.dart';
 import 'package:inter_knot/pages/create_discussion/create_discussion_desktop_sidebar.dart';
@@ -56,8 +53,7 @@ class _CreateDiscussionPageState extends State<CreateDiscussionPage> {
 
   final PageController _pageController = PageController();
   final titleController = TextEditingController();
-  final _mobileBodyController = TextEditingController();
-  final _quillController = quill.QuillController.basic();
+  final _bodyController = TextEditingController();
 
   // Images State — each image is tracked as an UploadTask with its own status/progress
   final RxList<UploadTask> _uploadTasks = <UploadTask>[].obs;
@@ -105,8 +101,7 @@ class _CreateDiscussionPageState extends State<CreateDiscussionPage> {
         return;
       }
 
-      // 在光标位置插入占位符并开始上传
-      final index = _quillController.selection.start;
+      final index = _bodySelectionOffset;
       _uploadImageAndInsert(
         insertIndex: index,
         filename: filename,
@@ -276,7 +271,7 @@ class _CreateDiscussionPageState extends State<CreateDiscussionPage> {
     }
   }
 
-  /// 粘贴图片 -> 上传 -> 替换为 HTML 图片标签
+  /// 粘贴图片 -> 上传 -> 替换为 Markdown 图片语法
   void _uploadImageAndInsert({
     required int insertIndex,
     required String filename,
@@ -286,12 +281,10 @@ class _CreateDiscussionPageState extends State<CreateDiscussionPage> {
     final taskId = DateTime.now().millisecondsSinceEpoch.toString();
     final token = '{{uploading:$taskId}}';
 
-    // 插入占位符并移动光标到占位符后
-    _quillController.replaceText(
-      insertIndex,
-      0,
-      token,
-      TextSelection.collapsed(offset: insertIndex + token.length),
+    _replaceBodyRange(
+      start: insertIndex,
+      end: insertIndex,
+      replacement: token,
     );
 
     _uploadAndReplace(
@@ -342,42 +335,48 @@ class _CreateDiscussionPageState extends State<CreateDiscussionPage> {
       // 构建完整 URL
       final fullUrl = _toFullImageUrl(url);
 
-      // 使用 Quill Image Embed
-      _replaceTokenWithImage(token, fullUrl);
+      _replaceTokenWithImage(token, filename, fullUrl);
     } catch (e) {
       _replaceToken(token, '上传失败：$filename ($e)');
     }
   }
 
-  void _replaceTokenWithImage(String token, String imageUrl) {
+  int get _bodySelectionOffset {
+    final selection = _bodyController.selection;
+    if (!selection.isValid) return _bodyController.text.length;
+    final offset = selection.start;
+    if (offset < 0 || offset > _bodyController.text.length) {
+      return _bodyController.text.length;
+    }
+    return offset;
+  }
+
+  void _replaceBodyRange({
+    required int start,
+    required int end,
+    required String replacement,
+  }) {
+    final text = _bodyController.text;
+    final safeStart = start.clamp(0, text.length) as int;
+    final safeEnd = end.clamp(safeStart, text.length) as int;
+    final updated = text.replaceRange(safeStart, safeEnd, replacement);
+    _bodyController.value = TextEditingValue(
+      text: updated,
+      selection: TextSelection.collapsed(
+        offset: safeStart + replacement.length,
+      ),
+    );
+  }
+
+  void _replaceTokenWithImage(String token, String filename, String imageUrl) {
     final index = _findTokenIndex(token);
     if (index == null) return;
 
-    // 先删除 token
-    _quillController.replaceText(
-      index,
-      token.length,
-      '',
-      TextSelection.collapsed(offset: index),
-    );
-
-    // 插入图片 Embed
-    // 默认设置图片大小为 160px，以匹配封面上传样式
-    _quillController.document.insert(index, quill.BlockEmbed.image(imageUrl));
-    _quillController.formatText(index, 1,
-        const quill.Attribute('width', quill.AttributeScope.ignore, '160'));
-    _quillController.formatText(index, 1,
-        const quill.Attribute('height', quill.AttributeScope.ignore, '160'));
-    _quillController.formatText(
-        index,
-        1,
-        const quill.Attribute('style', quill.AttributeScope.ignore,
-            'display: inline; margin: 0 0 1em 0'));
-
-    // 移动光标到图片后 (Embed 长度为 1)
-    _quillController.updateSelection(
-      TextSelection.collapsed(offset: index + 1),
-      quill.ChangeSource.local,
+    final markdownImage = '![${filename.split('.').first}]($imageUrl)';
+    _replaceBodyRange(
+      start: index,
+      end: index + token.length,
+      replacement: markdownImage,
     );
   }
 
@@ -385,39 +384,15 @@ class _CreateDiscussionPageState extends State<CreateDiscussionPage> {
     final index = _findTokenIndex(token);
     if (index == null) return;
 
-    // 先删除 token，再插入 HTML，避免转义导致的替换错位
-    _quillController.replaceText(
-      index,
-      token.length,
-      '',
-      TextSelection.collapsed(offset: index),
-    );
-    _quillController.replaceText(
-      index,
-      0,
-      replacement,
-      TextSelection.collapsed(offset: index + replacement.length),
-    );
-    _quillController.updateSelection(
-      TextSelection.collapsed(offset: index + replacement.length),
-      quill.ChangeSource.local,
+    _replaceBodyRange(
+      start: index,
+      end: index + token.length,
+      replacement: replacement,
     );
   }
 
   int? _findTokenIndex(String token) {
-    final delta = _quillController.document.toDelta();
-    final buffer = StringBuffer();
-    for (final op in delta.toList()) {
-      final data = op.data;
-      if (data is String) {
-        buffer.write(data);
-      } else {
-        // embeds count as length 1 in document indices
-        buffer.write('\uFFFC');
-      }
-    }
-    final text = buffer.toString();
-    final pos = text.indexOf(token);
+    final pos = _bodyController.text.indexOf(token);
     if (pos == -1) return null;
     return pos;
   }
@@ -491,7 +466,7 @@ class _CreateDiscussionPageState extends State<CreateDiscussionPage> {
     final filename = file.name;
     final mimeType = file.mimeType ?? 'image/jpeg';
 
-    final index = _quillController.selection.start;
+    final index = _bodySelectionOffset;
     _uploadImageAndInsert(
       insertIndex: index,
       filename: filename,
@@ -504,8 +479,7 @@ class _CreateDiscussionPageState extends State<CreateDiscussionPage> {
   void dispose() {
     _pageController.dispose();
     titleController.dispose();
-    _mobileBodyController.dispose();
-    _quillController.dispose();
+    _bodyController.dispose();
     if (kIsWeb) {
       removePasteListener();
       removeDropZone();
@@ -524,20 +498,7 @@ class _CreateDiscussionPageState extends State<CreateDiscussionPage> {
 
     if (widget.discussion != null) {
       titleController.text = widget.discussion!.title;
-      _mobileBodyController.text = widget.discussion!.rawBodyText;
-      // Convert raw markdown to Delta for Quill
-      try {
-        final mdDocument = md.Document(
-          encodeHtml: false,
-          extensionSet: md.ExtensionSet.gitHubWeb,
-        );
-        final mdToDelta = MarkdownToDelta(markdownDocument: mdDocument);
-        final delta = mdToDelta.convert(widget.discussion!.rawBodyText);
-        _quillController.document = quill.Document.fromDelta(delta);
-      } catch (e) {
-        debugPrint('Markdown parsing failed: $e');
-        _quillController.document.insert(0, widget.discussion!.rawBodyText);
-      }
+      _bodyController.text = widget.discussion!.rawBodyText;
 
       // Load existing covers as already-done upload tasks
       for (final cover in widget.discussion!.coverImages) {
@@ -630,15 +591,9 @@ class _CreateDiscussionPageState extends State<CreateDiscussionPage> {
     return false;
   }
 
-  Future<void> _submit({bool isMobile = false}) async {
+  Future<void> _submit() async {
     final title = titleController.text.trim();
-    final String markdownText;
-    if (isMobile) {
-      markdownText = _mobileBodyController.text.trim();
-    } else {
-      final delta = _quillController.document.toDelta();
-      markdownText = normalizeMarkdown(DeltaToMarkdown().convert(delta));
-    }
+    final markdownText = _bodyController.text;
 
     // Pass all uploaded images as cover
     // If backend supports multiple, we send list.
@@ -662,7 +617,7 @@ class _CreateDiscussionPageState extends State<CreateDiscussionPage> {
       return;
     }
     // Content check: either text or images must exist
-    if (markdownText.isEmpty && _uploadedImages.isEmpty) {
+    if (markdownText.trim().isEmpty && _uploadedImages.isEmpty) {
       showToast('内容不能为空', isError: true);
       return;
     }
@@ -814,13 +769,12 @@ class _CreateDiscussionPageState extends State<CreateDiscussionPage> {
     final double zoomScale = isWindowed ? 1.1 : 1.0;
     final double layoutFactor = baseFactor * zoomScale;
 
-    // Mobile uses a simple TextField editor; desktop uses the Quill PageView
+    // Mobile and desktop now share the same Markdown text source.
     final mobileEditor = CreateDiscussionEditorPage(
       titleController: titleController,
-      quillController: _quillController,
+      bodyController: _bodyController,
       onPickAndUploadImage: _pickAndUploadImage,
       isMobile: true,
-      mobileBodyController: _mobileBodyController,
       mobileUploadTasks: _uploadTasks,
       onRemoveMobileImage: _removeUploadTask,
       onRetryMobileImage: _retryUploadTask,
@@ -838,7 +792,7 @@ class _CreateDiscussionPageState extends State<CreateDiscussionPage> {
       children: [
         CreateDiscussionEditorPage(
           titleController: titleController,
-          quillController: _quillController,
+          bodyController: _bodyController,
           onPickAndUploadImage: _pickAndUploadImage,
         ),
         CreateDiscussionCoverPage(
@@ -860,11 +814,11 @@ class _CreateDiscussionPageState extends State<CreateDiscussionPage> {
     final scaffold = Scaffold(
       backgroundColor: const Color(0xff121212),
       bottomNavigationBar: isDesktop
-          ? null
-          : Obx(() => CreateDiscussionMobileNav(
+              ? null
+              : Obx(() => CreateDiscussionMobileNav(
                 isLoading: isLoading,
                 onPickImage: _pickImages,
-                onSubmit: () => _submit(isMobile: true),
+                onSubmit: _submit,
                 imageCount: _uploadTasks.length,
                 uploadingCount: _uploadTasks
                     .where((t) =>

--- a/lib/pages/discussion/discussion_detail_box.dart
+++ b/lib/pages/discussion/discussion_detail_box.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:inter_knot/components/image_viewer.dart';
 import 'package:inter_knot/controllers/data.dart';
+import 'package:inter_knot/helpers/prepare_markdown_for_display.dart';
 import 'package:inter_knot/models/discussion.dart';
 import 'package:markdown_widget/markdown_widget.dart' hide ImageViewer;
 import 'package:url_launcher/url_launcher_string.dart';
@@ -42,7 +43,7 @@ class _DiscussionDetailBoxState extends State<DiscussionDetailBox> {
               const SizedBox(height: 16),
               SelectionArea(
                 child: MarkdownWidget(
-                  data: discussion.rawBodyText,
+                  data: prepareMarkdownForDisplay(discussion.rawBodyText),
                   shrinkWrap: true,
                   physics: const NeverScrollableScrollPhysics(),
                   config: MarkdownConfig.darkConfig.copy(


### PR DESCRIPTION
重构讨论创建和编辑页面，移除Quill富文本编辑器依赖，改为基于原生TextField的Markdown编辑器实现。新增编辑器工具栏支持常见Markdown语法快捷操作，并优化图片上传处理流程。

主要变更包括：
- 移除flutter_quill及相关依赖
- 实现原生Markdown编辑器核心功能
- 添加支持语法快捷操作的工具栏
- 重构图片上传逻辑以适配新编辑器
- 优化移动端和桌面端的编辑器体验一致性